### PR TITLE
Check starttls return code (CVE-2016-0772).

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -160,7 +160,10 @@ class Connection(object):
         host.set_debuglevel(int(self.mail.debug))
 
         if self.mail.use_tls:
-            host.starttls()
+            (resp, reply) = host.starttls()
+            # Fix CVE-2016-0772 on old Python installations
+            if resp != 200:
+                raise smtplib.SMTPResponseException(resp, reply)
         if self.mail.username and self.mail.password:
             host.login(self.mail.username, self.mail.password)
 


### PR DESCRIPTION
Same behavior as in latest smtplib: https://github.com/python/cpython/blob/master/Lib/smtplib.py#L731

Tested via unit tests against CPython 2.6, 2.7 and 3.4.

See: https://nvd.nist.gov/vuln/detail/CVE-2016-0772

Imported from https://github.com/mattupstate/flask-mail/pull/135