### PR TITLE
CVE-2016-0772

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -164,7 +164,10 @@ class Connection(object):
         host.set_debuglevel(int(self.mail.debug))
 
         if self.mail.use_tls:
-            host.starttls()
+            (resp, reply) = host.starttls()
+            # Fix CVE-2016-0772 on old Python installations
+            if resp != 200:
+                raise smtplib.SMTPResponseException(resp, reply)
         if self.mail.username and self.mail.password:
             host.login(self.mail.username, self.mail.password)
 

--- a/tests.py
+++ b/tests.py
@@ -8,13 +8,14 @@ import unittest
 import time
 import re
 import mock
+import smtplib
 from contextlib import contextmanager
 
 from email.header import Header
 from email import charset
 
 from flask import Flask
-from flask_mail import Mail, Message, BadHeaderError, sanitize_address, PY3
+from flask_mail import Mail, Message, BadHeaderError, sanitize_address, PY3, Connection
 from speaklater import make_lazy_string
 
 
@@ -781,3 +782,11 @@ class TestConnection(TestCase):
                         not_expected = sanitize_address(mail)
                         self.assertIn(expected, send_to)
                         self.assertNotIn(not_expected, send_to)
+                        
+    def test_configure_host_tls_failure(self):
+        with mock.patch('flask_mail.smtplib.SMTP') as MockSMTP:
+            mock_host = MockSMTP.return_value
+            mock_host.starttls.return_value = (501, "Syntax error (testing)")
+            with mock.patch.object(self.mail, "use_tls", True):
+                self.assertTrue(self.mail.use_tls)
+                self.assertRaises(smtplib.SMTPResponseException, Connection(self.mail).configure_host)


### PR DESCRIPTION
Same behavior as in latest smtplib: https://github.com/python/cpython/blob/master/Lib/smtplib.py#L731

Tested via unit tests against CPython 2.6, 2.7 and 3.4.

See: https://nvd.nist.gov/vuln/detail/CVE-2016-0772

Imported from https://github.com/mattupstate/flask-mail/pull/135

Supersedes #3